### PR TITLE
Use optional type for backgroundImage

### DIFF
--- a/Swift/OnboardSwift/OnboardingViewController.swift
+++ b/Swift/OnboardSwift/OnboardingViewController.swift
@@ -17,7 +17,7 @@ class OnboardingViewController: UIViewController, UIPageViewControllerDataSource
     var contents: [OnboardingContentViewController] = []
     var shouldMaskBackground: Bool = true
     
-    init(backgroundImage: UIImage, contents: [OnboardingContentViewController]) {
+    init(backgroundImage: UIImage?, contents: [OnboardingContentViewController]) {
         self.backgroundImage = backgroundImage
         self.contents = contents
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
After I cloned the project and tried to play around, I immediately found that the Swift project can be compiled due to a type error.
