### PR TITLE
Allow subclassing

### DIFF
--- a/Objective-C/Onboard/OnboardingViewController.m
+++ b/Objective-C/Onboard/OnboardingViewController.m
@@ -38,7 +38,7 @@ static NSString * const kSkipButtonText = @"Skip";
  }
 
 - (instancetype)initWithBackgroundImage:(UIImage *)backgroundImage contents:(NSArray *)contents {
-    self = [[OnboardingViewController alloc] initWithContents:contents];
+    self = [self initWithContents:contents];
     
     // store the passed in view controllers array
     _backgroundImage = backgroundImage;
@@ -55,7 +55,7 @@ static NSString * const kSkipButtonText = @"Skip";
 }
 
 - (instancetype)initWithBackgroundVideoURL:(NSURL *)backgroundVideoURL contents:(NSArray *)contents {
-    self = [[OnboardingViewController alloc] initWithContents:contents];
+    self = [self initWithContents:contents];
     
     // store the passed in video URL
     _videoURL = backgroundVideoURL;


### PR DESCRIPTION
Allow subclassing by calling "self" instead of "OnboardingViewController alloc".
In order to allow subclassing (i.e. to disable autorotating and setting supportedInterfaceOrientations) the init method should call [self initWithContents:] instead of [[OnboardingViewController alloc] initWithContents:]
