### PR TITLE
Added auto-sizing of icon based on image

### DIFF
--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -53,8 +53,13 @@ static CGFloat const kMainPageControlHeight = 35;
     self.movesToNextViewController = NO;
     
     // default icon properties
-    self.iconHeight = kDefaultImageViewSize;
-    self.iconWidth = kDefaultImageViewSize;
+	if(_image){
+		self.iconHeight = _image.size.height;
+		self.iconWidth = _image.size.width;
+	} else {
+		self.iconHeight = kDefaultImageViewSize;
+		self.iconWidth = kDefaultImageViewSize;
+	}
     
     // default title properties
     self.titleFontName = kDefaultOnboardingFont;


### PR DESCRIPTION
I don't know how you feel about this, given it could be done from outside of the framework by setting the size properties based on the image file, but it seemed like something the framework could do pretty easily and would make for sensible defaults.

Changed the default icon size to be pulled from the icon file, instead of using the hardcoded default size. Icon sizes can still be overridden using the properties for those who need this functionality.

Also I didn't make this change on the Swift side of things. Don't know if that's a big deal or not.