### PR TITLE
Action blocks

### DIFF
--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -15,7 +15,7 @@
     NSString *_body;
     UIImage *_image;
     NSString *_buttonText;
-    dispatch_block_t _actionHandler;
+    void(^_actionHandler)(OnboardingContentViewController *onboardingContentController);
     
     UIImageView *_imageView;
     UILabel *_mainTextLabel;
@@ -51,9 +51,11 @@
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;
 
-+ (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;
-- (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;
++ (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(void(^)(OnboardingContentViewController *onboardingContentController))action;
+- (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(void(^)(OnboardingContentViewController *onboardingContentController))action;
 
 - (void)updateAlphas:(CGFloat)newAlpha;
+
+- (void)moveNextPage;
 
 @end

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -32,12 +32,12 @@ static CGFloat const kMainPageControlHeight = 35;
 
 @implementation OnboardingContentViewController
 
-+ (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action {
++ (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(void(^)(OnboardingContentViewController *onboardingContentController))action {
     OnboardingContentViewController *contentVC = [[self alloc] initWithTitle:title body:body image:image buttonText:buttonText action:action];
     return contentVC;
 }
 
-- (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action {
+- (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(void(^)(OnboardingContentViewController *onboardingContentController))action {
     self = [super init];
 
     // hold onto the passed in parameters, and set the action block to an empty block
@@ -47,7 +47,7 @@ static CGFloat const kMainPageControlHeight = 35;
     _body = body;
     _image = image;
     _buttonText = buttonText;
-    _actionHandler = action ?: ^{};
+    _actionHandler = action ?: ^(OnboardingContentViewController *controller){};
     
     // default auto-navigation
     self.movesToNextViewController = NO;
@@ -185,11 +185,15 @@ static CGFloat const kMainPageControlHeight = 35;
     // if we want to navigate to the next view controller, tell our delegate
     // to handle it
     if (self.movesToNextViewController) {
-        [self.delegate moveNextPage];
+        [self moveNextPage];
     }
     
     // call the provided action handler
-    _actionHandler();
+    _actionHandler(self);
+}
+
+- (void)moveNextPage{
+	[self.delegate moveNextPage];
 }
 
 @end


### PR DESCRIPTION
I made some changes to the action blocks. I know these are breaking changes, but with autocomplete it shouldn't be too big of an update for existing users. If this looks good I can make the necessary updates to the README file as well.

The idea here is to pass a reference to self in the action block, so the handler can do things like skip to the next page. Here is an example of the desired usage:

	OnboardingContentViewController *page = [OnboardingContentViewController contentWithTitle:@"Page Title" body:@"Page body goes here." image:[UIImage imageNamed:@"icon"] buttonText:@"Text For Button" action:^(OnboardingContentViewController *onboardingContentController) {
		// start some long async process

		// show progress HUD or something

		// all done and everything succeeded, ready to move on
		[onboardingContentController moveNextPage];
	}];

This allows for a bit more control than just the `movesToNextViewController` property.