### PR TITLE
added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 #Xcode
 *.pbuser
 *.mode1v3


### PR DESCRIPTION
Finder constantly litters .DS_Store files all over the filesystem. Adding this to .gitignore prevents them from being accidentally committed via a `git commit -a`, etc.