### PR TITLE
Added parallel blocks to hook into view(Will|Did)Disappear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 #Xcode
 *.pbuser
 *.mode1v3

--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -50,6 +50,8 @@
 
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;
+@property (nonatomic, copy) dispatch_block_t viewWillDisappearBlock;
+@property (nonatomic, copy) dispatch_block_t viewDidDisappearBlock;
 
 + (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;
 - (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -126,6 +126,20 @@ static CGFloat const kMainPageControlHeight = 35;
     self.viewDidAppearBlock();
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+
+    // call our view will disappear block
+    self.viewWillDisappearBlock();
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+
+    // call our view did disappear block
+    self.viewDidDisappearBlock();
+}
+
 - (void)generateView {
     // we want our background to be clear so we can see through it to the image provided
     self.view.backgroundColor = [UIColor clearColor];

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -89,7 +89,9 @@ static CGFloat const kMainPageControlHeight = 35;
     // default blocks
     self.viewWillAppearBlock = ^{};
     self.viewDidAppearBlock = ^{};
-    
+    self.viewWillDisappearBlock = ^{};
+    self.viewDidDisappearBlock = ^{};
+
     return self;
 }
 


### PR DESCRIPTION
The blocks that allow hooking into `view(Will|Did)Appear:` are useful, and I came across a scenario in which performing cleanup during the `viewWillDisappear:` and/or `viewDidDisappear:` calls would be helpful.

So, I added the equivalent blocks for those methods in this pull request.