### PR TITLE
Expose the button handler action as a property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 #Xcode
 *.pbuser
 *.mode1v3

--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -50,6 +50,8 @@
 
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;
+@property (nonatomic, copy) dispatch_block_t viewWillDisappearBlock;
+@property (nonatomic, copy) dispatch_block_t viewDidDisappearBlock;
 
 + (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;
 - (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;

--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -15,7 +15,6 @@
     NSString *_body;
     UIImage *_image;
     NSString *_buttonText;
-    dispatch_block_t _actionHandler;
     
     UIImageView *_imageView;
     UILabel *_mainTextLabel;
@@ -47,6 +46,8 @@
 @property (nonatomic) CGFloat underIconPadding;
 @property (nonatomic) CGFloat underTitlePadding;
 @property (nonatomic) CGFloat bottomPadding;
+
+@property (nonatomic, copy) dispatch_block_t buttonActionHandler;
 
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -126,6 +126,20 @@ static CGFloat const kMainPageControlHeight = 35;
     self.viewDidAppearBlock();
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+
+    // call our view will disappear block
+    self.viewWillDisappearBlock();
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+
+    // call our view did disappear block
+    self.viewDidDisappearBlock();
+}
+
 - (void)generateView {
     // we want our background to be clear so we can see through it to the image provided
     self.view.backgroundColor = [UIColor clearColor];

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -47,7 +47,8 @@ static CGFloat const kMainPageControlHeight = 35;
     _body = body;
     _image = image;
     _buttonText = buttonText;
-    _actionHandler = action ?: ^{};
+
+    self.buttonActionHandler = action;
     
     // default auto-navigation
     self.movesToNextViewController = NO;
@@ -142,6 +143,11 @@ static CGFloat const kMainPageControlHeight = 35;
     self.viewDidDisappearBlock();
 }
 
+- (void)setButtonActionHandler:(dispatch_block_t)action
+{
+    _buttonActionHandler = action ?: ^{};
+}
+
 - (void)generateView {
     // we want our background to be clear so we can see through it to the image provided
     self.view.backgroundColor = [UIColor clearColor];
@@ -212,7 +218,7 @@ static CGFloat const kMainPageControlHeight = 35;
     }
     
     // call the provided action handler
-    _actionHandler();
+    _buttonActionHandler();
 }
 
 @end

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -89,7 +89,9 @@ static CGFloat const kMainPageControlHeight = 35;
     // default blocks
     self.viewWillAppearBlock = ^{};
     self.viewDidAppearBlock = ^{};
-    
+    self.viewWillDisappearBlock = ^{};
+    self.viewDidDisappearBlock = ^{};
+
     return self;
 }
 


### PR DESCRIPTION
There's a Catch-22 with Swift constructors that makes it difficult to use the button handler.

Specifically, because the button handler was only settable from the constructor, it was not possible to use in cases where the button handler needed to reference the view controller itself.

It's probably hard to visualize, so imagine this scenario:

You want to subclass OnboardingContentViewController from Swift. Within your subclass's `init`, you attempt to call `super` as follows:

````swift
super.init(title: "Hi!", body: "How are you?", image: nil, buttonText: "Great!", action: {
    self.buttonTapped()
})
```

This scenario won't compile, because Swift won't allow you to use `self` from within `init` before `super` has been called. In this instance, the action block contains a reference to `self`; since the action block is a parameter to `super.init()`, the reference contained inside is illegal and results in build error.

By making it possible to set the button action handler after construction, it is now possible to achieve the desired result with:

````swift
super.init(title: "Hi!", body: "How are you?", image: nil, buttonText: "Great!", action: nil)
self.buttonActionHandler = { self.buttonTapped() }
```
