### PR TITLE
Change where delegate property is set to ensure it is populated when first viewWillAppear: is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 #Xcode
 *.pbuser
 *.mode1v3

--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -50,6 +50,8 @@
 
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;
+@property (nonatomic, copy) dispatch_block_t viewWillDisappearBlock;
+@property (nonatomic, copy) dispatch_block_t viewDidDisappearBlock;
 
 + (instancetype)contentWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;
 - (instancetype)initWithTitle:(NSString *)title body:(NSString *)body image:(UIImage *)image buttonText:(NSString *)buttonText action:(dispatch_block_t)action;

--- a/Objective-C/Onboard/OnboardingContentViewController.h
+++ b/Objective-C/Onboard/OnboardingContentViewController.h
@@ -15,7 +15,6 @@
     NSString *_body;
     UIImage *_image;
     NSString *_buttonText;
-    dispatch_block_t _actionHandler;
     
     UIImageView *_imageView;
     UILabel *_mainTextLabel;
@@ -47,6 +46,8 @@
 @property (nonatomic) CGFloat underIconPadding;
 @property (nonatomic) CGFloat underTitlePadding;
 @property (nonatomic) CGFloat bottomPadding;
+
+@property (nonatomic, copy) dispatch_block_t buttonActionHandler;
 
 @property (nonatomic, copy) dispatch_block_t viewWillAppearBlock;
 @property (nonatomic, copy) dispatch_block_t viewDidAppearBlock;

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -126,6 +126,20 @@ static CGFloat const kMainPageControlHeight = 35;
     self.viewDidAppearBlock();
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+
+    // call our view will disappear block
+    self.viewWillDisappearBlock();
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+
+    // call our view did disappear block
+    self.viewDidDisappearBlock();
+}
+
 - (void)generateView {
     // we want our background to be clear so we can see through it to the image provided
     self.view.backgroundColor = [UIColor clearColor];

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -47,7 +47,8 @@ static CGFloat const kMainPageControlHeight = 35;
     _body = body;
     _image = image;
     _buttonText = buttonText;
-    _actionHandler = action ?: ^{};
+
+    self.buttonActionHandler = action;
     
     // default auto-navigation
     self.movesToNextViewController = NO;
@@ -142,6 +143,11 @@ static CGFloat const kMainPageControlHeight = 35;
     self.viewDidDisappearBlock();
 }
 
+- (void)setButtonActionHandler:(dispatch_block_t)action
+{
+    _buttonActionHandler = action ?: ^{};
+}
+
 - (void)generateView {
     // we want our background to be clear so we can see through it to the image provided
     self.view.backgroundColor = [UIColor clearColor];
@@ -212,7 +218,7 @@ static CGFloat const kMainPageControlHeight = 35;
     }
     
     // call the provided action handler
-    _actionHandler();
+    _buttonActionHandler();
 }
 
 @end

--- a/Objective-C/Onboard/OnboardingContentViewController.m
+++ b/Objective-C/Onboard/OnboardingContentViewController.m
@@ -89,7 +89,9 @@ static CGFloat const kMainPageControlHeight = 35;
     // default blocks
     self.viewWillAppearBlock = ^{};
     self.viewDidAppearBlock = ^{};
-    
+    self.viewWillDisappearBlock = ^{};
+    self.viewDidDisappearBlock = ^{};
+
     return self;
 }
 

--- a/Objective-C/Onboard/OnboardingViewController.m
+++ b/Objective-C/Onboard/OnboardingViewController.m
@@ -144,7 +144,13 @@ static NSString * const kSkipButtonText = @"Skip";
         backgroundMaskView.backgroundColor = [UIColor colorWithWhite:0.0 alpha:kBackgroundMaskAlpha];
         [_pageVC.view addSubview:backgroundMaskView];
     }
-    
+
+    // set ourself as the delegate on all of the content views, to handle fading
+    // and auto-navigation
+    for (OnboardingContentViewController *contentVC in self.viewControllers) {
+        contentVC.delegate = self;
+    }
+
     // set the initial current page as the first page provided
     _currentPage = [self.viewControllers firstObject];
     
@@ -197,12 +203,6 @@ static NSString * const kSkipButtonText = @"Skip";
                 [(UIScrollView *)view setDelegate:self];
             }
         }
-    }
-    
-    // set ourself as the delegate on all of the content views, to handle fading
-    // and auto-navigation
-    for (OnboardingContentViewController *contentVC in self.viewControllers) {
-        contentVC.delegate = self;
     }
 }
 


### PR DESCRIPTION
The following line in the `generateView` method of the `OnboardingViewController` class causes the `viewWillAppear:` method of the `_currentPage` to be executed:

```objc
[_pageVC setViewControllers:@[_currentPage] direction:UIPageViewControllerNavigationDirectionForward animated:YES completion:nil];
```

Because this method call occurs prior to the setting of the content view controllers' `delegate` property, when the `_currentPage`'s `viewWillAppear:` is executed, its `delegate` property will be `nil`.

This pull request moves the following lines further up in the `generateView` method so that the `delegate` value is available from within the  `_currentPage`'s `viewWillAppear:` method as expected.