### PR TITLE
Animated background change

### DIFF
--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -148,13 +148,13 @@ static NSString * const kSkipButtonText = @"Skip";
     UIImageView *backgroundImageView;
     
     // create the background image view and set it to aspect fill so it isn't skewed
+    backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
+    backgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
     if (self.backgroundImage) {
-        backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
-        backgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
         [backgroundImageView setImage:self.backgroundImage];
-        [self.view addSubview:backgroundImageView];
-        self.backgroundImageView = backgroundImageView;
     }
+    self.backgroundImageView = backgroundImageView;
+    [self.view addSubview:backgroundImageView];
     
     // as long as the shouldMaskBackground setting hasn't been set to NO, we want to
     // create a partially opaque view and add it on top of the image view, so that it

--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -19,6 +19,12 @@ static CGFloat const kDefaultSaturationDeltaFactor = 1.8;
 
 static NSString * const kSkipButtonText = @"Skip";
 
+@interface OnboardingViewController ()
+
+@property (nonatomic, weak) UIImageView *backgroundImageView;
+
+@end
+
 @implementation OnboardingViewController {
     NSURL *_videoURL;
     UIPageViewController *_pageVC;
@@ -147,6 +153,7 @@ static NSString * const kSkipButtonText = @"Skip";
         backgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
         [backgroundImageView setImage:self.backgroundImage];
         [self.view addSubview:backgroundImageView];
+        self.backgroundImageView = backgroundImageView;
     }
     
     // as long as the shouldMaskBackground setting hasn't been set to NO, we want to
@@ -458,6 +465,11 @@ static NSString * const kSkipButtonText = @"Skip";
 
 
 #pragma mark - Image blurring
+
+- (void)setBackgroundImage:(UIImage *)backgroundImage {
+    _backgroundImage = backgroundImage;
+    [_backgroundImageView setImage:_backgroundImage];
+}
 
 - (void)blurBackground {
     // Check pre-conditions.

--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -467,8 +467,21 @@ static NSString * const kSkipButtonText = @"Skip";
 #pragma mark - Image blurring
 
 - (void)setBackgroundImage:(UIImage *)backgroundImage {
+    BOOL animate = _backgroundImage != nil;
     _backgroundImage = backgroundImage;
-    [_backgroundImageView setImage:_backgroundImage];
+    if (!_backgroundImageView) {
+        return;
+    }
+    if (!animate) {
+        _backgroundImageView.image = _backgroundImage;
+        return;
+    }
+    [UIView transitionWithView:_backgroundImageView
+                      duration:0.5f
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:^{
+                        _backgroundImageView.image = backgroundImage;
+                    } completion:nil];
 }
 
 - (void)blurBackground {


### PR DESCRIPTION
Allows background image to be changed with cross-dissolve animation like this:

    OnboardingContentViewController *firstPage = // ...
		__weak OnboardingContentViewController *_firstPage = firstPage;
    firstPage.viewWillAppearBlock = ^{
        [[_firstPage delegate] setBackgroundImage:[UIImage imageNamed:@"bg1"]];
    };

    OnboardingContentViewController *secondPage = // ...
    __weak OnboardingContentViewController *_secondPage = secondPage;
    secondPage.viewWillAppearBlock = ^{
        [[_secondPage delegate] setBackgroundImage:[UIImage imageNamed:@"onboard_club"]];
    };

    OnboardingViewController *onboardingVC = [OnboardingViewController onboardWithBackgroundImage:nil contents:@[firstPage, secondPage, thirdPage]];

Animation is triggered only if background image already exists.
Type of animation is for now hardwired to 500ms cross-dissolve.