### PR TITLE
tells skip button to handle long titles properly

### DIFF
--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -90,6 +90,7 @@ static NSString * const kSkipButtonText = @"Skip";
     self.skipButton = [UIButton new];
     [self.skipButton setTitle:kSkipButtonText forState:UIControlStateNormal];
     [self.skipButton addTarget:self action:@selector(handleSkipButtonPressed) forControlEvents:UIControlEventTouchUpInside];
+    self.skipButton.titleLabel.adjustsFontSizeToFitWidth = YES;
 
     // create the movie player controller
     self.moviePlayerController = [MPMoviePlayerController new];


### PR DESCRIPTION
turns out the word 'skip' in Dutch or German is way longer than in English :D