### PR TITLE
disable UIPageViewController's bounce

### DIFF
--- a/Source/OnboardingViewController.h
+++ b/Source/OnboardingViewController.h
@@ -103,6 +103,12 @@
 
 
 /**
+ * @brief Determines whether or not disable UIPageViewController's bounce. The default value of this property is NO.
+ */
+@property (nonatomic) BOOL disableBounce;
+
+
+/**
  * @brief Convenience class initializer for onboarding with a backround image.
  * @return An instance of OnboardingViewController with the provided background image and content view controllers.
  */

--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -94,6 +94,7 @@ static NSString * const kSkipButtonText = @"Skip";
     self.fadePageControlOnLastPage = NO;
     self.fadeSkipButtonOnLastPage = NO;
     self.swipingEnabled = YES;
+    self.disableBounce = NO;
     
     self.allowSkipping = NO;
     self.skipHandler = ^{};
@@ -465,6 +466,24 @@ static NSString * const kSkipButtonText = @"Skip";
 
         else if (transitioningFromLastPage) {
             _skipButton.alpha = percentComplete;
+        }
+    }
+    
+    if (self.disableBounce) {
+        if (_currentPage == self.viewControllers.firstObject && scrollView.contentOffset.x <= scrollView.bounds.size.width) {
+            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+        } else if (_currentPage == self.viewControllers.lastObject && scrollView.contentOffset.x >= scrollView.bounds.size.width) {
+            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+        }
+    }
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
+    if (self.disableBounce) {
+        if (_currentPage == self.viewControllers.firstObject && scrollView.contentOffset.x <= scrollView.bounds.size.width) {
+            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
+        } else if (_currentPage == self.viewControllers.lastObject && scrollView.contentOffset.x >= scrollView.bounds.size.width) {
+            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
         }
     }
 }


### PR DESCRIPTION
When I prefer to use an image to fill content viewcontroller for onboarding, UIPageViewController's bounce leads me to a bad experience at the first and last page. So I add a property "disableBounce" to disable UIPageViewController's bounce.  (sorry for my bad english)