### PR TITLE
Fixes a display issue on iPad

### DIFF
--- a/Onboard.podspec
+++ b/Onboard.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Mike Amaral" => "mike.amaral36@gmail.com" }
   s.social_media_url   = "http://twitter.com/MikeAmaral"
   s.platform     = :ios
-  s.source       = { :git => "https://github.com/Kjens93/Onboard.git", :tag => "v2.2.0" }
+  s.source       = { :git => "https://github.com/mamaral/Onboard.git", :tag => "v2.2.0" }
   s.source_files  = "Source/OnboardingViewController.{h,m}", "Source/OnboardingContentViewController.{h,m}"
   s.requires_arc = true
 

--- a/Onboard.podspec
+++ b/Onboard.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Mike Amaral" => "mike.amaral36@gmail.com" }
   s.social_media_url   = "http://twitter.com/MikeAmaral"
   s.platform     = :ios
-  s.source       = { :git => "https://github.com/mamaral/Onboard.git", :tag => "v2.2.0" }
+  s.source       = { :git => "https://github.com/Kjens93/Onboard.git", :tag => "v2.2.0" }
   s.source_files  = "Source/OnboardingViewController.{h,m}", "Source/OnboardingContentViewController.{h,m}"
   s.requires_arc = true
 

--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -161,6 +161,7 @@ static NSString * const kSkipButtonText = @"Skip";
     // create the background image view and set it to aspect fill so it isn't skewed
     if (self.backgroundImage) {
         backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
+        backgroundImageView.clipsToBounds = YES;
         backgroundImageView.contentMode = UIViewContentModeScaleAspectFill;
         [backgroundImageView setImage:self.backgroundImage];
         [self.view addSubview:backgroundImageView];


### PR DESCRIPTION
Fixes an issue where the background image would spill beyond the top frame boundary on iPad.

# Before:
![before](https://cloud.githubusercontent.com/assets/15389109/16705449/68c13c84-4547-11e6-9734-ec2acc789a1f.gif)

# After:
![giphy-2](https://cloud.githubusercontent.com/assets/15389109/16705450/75168a8e-4547-11e6-8640-e7fb8aabdbca.gif)
