### PR TITLE
One page swipe "crash" fix

### DIFF
--- a/Source/OnboardingViewController.m
+++ b/Source/OnboardingViewController.m
@@ -348,7 +348,7 @@ static NSString * const kSkipButtonText = @"Skip";
 
     // determine if we're transitioning to or from our last page
     BOOL transitioningToLastPage = (_currentPage != self.viewControllers.lastObject && _upcomingPage == self.viewControllers.lastObject);
-    BOOL transitioningFromLastPage = (_currentPage == self.viewControllers.lastObject) && (_upcomingPage == self.viewControllers[self.viewControllers.count - 2]);
+    BOOL transitioningFromLastPage = (self.viewControllers.count > 1) && (_currentPage == self.viewControllers.lastObject) && (_upcomingPage == self.viewControllers[self.viewControllers.count - 2]);
     
     // fade the page control to and from the last page
     if (self.fadePageControlOnLastPage) {


### PR DESCRIPTION
Fix for:
Onboard with just one page and swipingEnabled = YES combination caused Exception and crashed the app when swiping.
The fix:
Added “self.viewControllers.count > 1” condition to the beginning of the transitioningFromLastPage boolean evaulation.
The error was indexing out of the “self.viewControllers” array’s range.